### PR TITLE
Fixes exception of wrong document length

### DIFF
--- a/src/idea/plugin/psiviewer/view/EditorPsiElementHighlighter.java
+++ b/src/idea/plugin/psiviewer/view/EditorPsiElementHighlighter.java
@@ -77,8 +77,9 @@ class EditorPsiElementHighlighter
         {
             TextRange textRange = element.getTextRange();
             debug("Adding highlighting for " + textRange);
+            final int docTextLength = _editor.getDocument().getTextLength();
             _highlighter = _editor.getMarkupModel().addRangeHighlighter(textRange.getStartOffset(),
-                                                                        textRange.getEndOffset(),
+                                                                        Math.min(textRange.getEndOffset(), docTextLength),
                                                                         PsiViewerConstants.PSIVIEWER_HIGHLIGHT_LAYER,
                                                                         _textAttributes,
                                                                         HighlighterTargetArea.EXACT_RANGE);


### PR DESCRIPTION
When you delete characters from the end of the file and you are using PsiViewer, an exception is thrown that the highlighting range goes beyond the documents end. I used the autoreporter to file and issue in your YouTrack database.

This should fix the issue.
