### PR TITLE
Occasional swing crash and MultiPsiDocuments support

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/idea/plugin/psiviewer/controller/application/Configuration.java
+++ b/src/idea/plugin/psiviewer/controller/application/Configuration.java
@@ -167,7 +167,7 @@ public class Configuration implements ApplicationComponent, JDOMExternalizable, 
 
     public static Configuration getInstance()
     {
-        return (Configuration) ApplicationManager.getApplication().getComponent(Configuration.class);
+        return ApplicationManager.getApplication().getComponent(Configuration.class);
     }
 
 }

--- a/src/idea/plugin/psiviewer/view/PropertySheetPanel.java
+++ b/src/idea/plugin/psiviewer/view/PropertySheetPanel.java
@@ -4,7 +4,11 @@
 package idea.plugin.psiviewer.view;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.table.JBTable;
+import com.intellij.xml.util.XmlStringUtil;
+import com.intellij.xml.util.XmlUtil;
 import idea.plugin.psiviewer.util.IntrospectionUtil;
 
 import javax.swing.*;
@@ -55,8 +59,15 @@ public class PropertySheetPanel extends JPanel
         {
             String key = property.getDisplayName();
             String value = formattedToString(IntrospectionUtil.getValue(_target, property));
+
+            if(StringUtil.isNotEmpty(value) && StringUtil.startsWithIgnoreCase(value, "<html>"))
+            {
+                value = "<html>" + XmlUtil.escape(value) + "</html>";
+            }
+
             map.put(key, value);
         }
+
         int i = 0;
         for (Iterator<Map.Entry<Object,String>> it = map.entrySet().iterator(); it.hasNext(); i++)
         {
@@ -117,6 +128,8 @@ public class PropertySheetPanel extends JPanel
                 int row = rowAtPoint(event.getPoint());
                 return getCellRect(row, col, INCLUDE_INTERCELL_SPACING).getLocation();
             }
+
+
         }
 ;
         _table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
@@ -174,7 +187,7 @@ public class PropertySheetPanel extends JPanel
         StringBuffer buf = new StringBuffer();
         buf.append("[");
         Object[] array = (Object[]) object;
-        for (int i = 0; i < array.length; i++)
+        for (int i = 0; i < array.length; i++) // fixme what if length is 100_500_000 ?
         {
             if (i != 0) buf.append(", ");
             buf.append(array[i] == null ? "null" : array[i].toString());

--- a/src/idea/plugin/psiviewer/view/PsiViewerPanel.java
+++ b/src/idea/plugin/psiviewer/view/PsiViewerPanel.java
@@ -33,6 +33,8 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.Function;
+import com.intellij.util.containers.ContainerUtil;
 import idea.plugin.psiviewer.PsiViewerConstants;
 import idea.plugin.psiviewer.controller.project.PsiViewerProjectComponent;
 import idea.plugin.psiviewer.model.PsiViewerTreeModel;
@@ -305,13 +307,24 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
         if (rootElement instanceof PsiFile)
         {
             FileViewProvider viewProvider = ((PsiFile) rootElement).getViewProvider();
-            _projectComponent.updateLanguagesList(viewProvider.getLanguages());
+
+            // iteration need, because getLanguages returns Set, not list, order is random
+            _projectComponent.updateLanguagesList(ContainerUtil.map(viewProvider.getAllFiles(), new Function<PsiFile, Language>() {
+                @Override
+                public Language fun(PsiFile psiFile)
+                {
+                    return psiFile.getLanguage();
+                }
+            }));
             Language selectedLanguage = _projectComponent.getSelectedLanguage();
 
             if (selectedLanguage != null)
             {
                 PsiElement selectedRoot = viewProvider.getPsi(selectedLanguage);
-                rootElement = selectedRoot;
+                if( selectedRoot != null )
+                {
+                    rootElement = selectedRoot;
+                }
             }
         }
         _rootElement = rootElement;

--- a/src/idea/plugin/psiviewer/view/PsiViewerPanel.java
+++ b/src/idea/plugin/psiviewer/view/PsiViewerPanel.java
@@ -21,11 +21,13 @@
 */
 package idea.plugin.psiviewer.view;
 
+import com.intellij.lang.Language;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -52,8 +54,7 @@ import java.util.LinkedList;
  */
 // TODO should be a project component. Move from PsiViewerProjectcomponent the initialization to here
 
-public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstants
-{
+public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstants {
     private static final Logger LOG = Logger.getInstance("idea.plugin.psiviewer.view.PsiViewerPanel");
 
     private String _actionTitle;
@@ -70,13 +71,13 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
     private final EditorPsiElementHighlighter _highlighter;
     private final PsiViewerProjectComponent _projectComponent;
     private final PropertySheetHeaderRenderer _propertyHeaderRenderer =
-        new PropertySheetHeaderRenderer(Helpers.getIcon(PsiViewerConstants.ICON_PSI),
-                                        SwingConstants.LEFT,
-                                        BorderFactory.createEtchedBorder());
+            new PropertySheetHeaderRenderer(Helpers.getIcon(PsiViewerConstants.ICON_PSI),
+                    SwingConstants.LEFT,
+                    BorderFactory.createEtchedBorder());
     private final PropertySheetHeaderRenderer _valueHeaderRenderer =
-        new PropertySheetHeaderRenderer(Helpers.getIcon(PsiViewerConstants.ICON_PSI),
-                                        SwingConstants.LEFT,
-                                        BorderFactory.createEtchedBorder());
+            new PropertySheetHeaderRenderer(Helpers.getIcon(PsiViewerConstants.ICON_PSI),
+                    SwingConstants.LEFT,
+                    BorderFactory.createEtchedBorder());
 
     public PsiViewerPanel(PsiViewerProjectComponent projectComponent)
     {
@@ -158,8 +159,7 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
         _tree.getSelectionModel().addTreeSelectionListener(_treeSelectionListener);
 
         ActionMap actionMap = _tree.getActionMap();
-        actionMap.put("EditSource", new AbstractAction("EditSource")
-        {
+        actionMap.put("EditSource", new AbstractAction("EditSource") {
             public void actionPerformed(ActionEvent e)
             {
                 debug("key typed " + e);
@@ -174,8 +174,7 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
 
         _propertyPanel = new PropertySheetPanel();
 
-        _splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, new JBScrollPane(_tree), _propertyPanel)
-        {
+        _splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, new JBScrollPane(_tree), _propertyPanel) {
             public void setDividerLocation(int location)
             {
                 debug("Divider location changed to " + location + " component below " + (getRightComponent().isVisible() ? "visible" : "not visible"));
@@ -192,12 +191,11 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
     {
     }
 
-    private class ViewerTreeSelectionListener implements TreeSelectionListener
-    {
+    private class ViewerTreeSelectionListener implements TreeSelectionListener {
         public void valueChanged(TreeSelectionEvent e)
         {
             setSelectedElement((PsiElement) _tree.getLastSelectedPathComponent(),
-                               PsiViewerPanel.TREE_SELECTION_CHANGED);
+                    PsiViewerPanel.TREE_SELECTION_CHANGED);
         }
     }
 
@@ -304,13 +302,27 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
 
     private void setRootElement(PsiElement rootElement)
     {
+        if (rootElement instanceof PsiFile)
+        {
+            FileViewProvider viewProvider = ((PsiFile) rootElement).getViewProvider();
+            _projectComponent.updateLanguagesList(viewProvider.getLanguages());
+            Language selectedLanguage = _projectComponent.getSelectedLanguage();
+
+            if (selectedLanguage != null)
+            {
+                PsiElement selectedRoot = viewProvider.getPsi(selectedLanguage);
+                rootElement = selectedRoot;
+            }
+        }
         _rootElement = rootElement;
         showRootElement();
     }
 
-    public void selectElementAtCaret() {
+    public void selectElementAtCaret()
+    {
         selectElementAtCaret(FileEditorManager.getInstance(_project).getSelectedTextEditor(), null);
     }
+
     public void selectElementAtCaret(@Nullable Editor editor, @Nullable String changeSource)
     {
         if (editor == null) /* Vince Mallet (21 Oct 2003) */
@@ -322,15 +334,36 @@ public class PsiViewerPanel extends JPanel implements Runnable, PsiViewerConstan
         PsiFile psiFile = PsiDocumentManager.getInstance(_project).getPsiFile(editor.getDocument());
 
         PsiElement elementAtCaret = null;
-        if (psiFile != null) {
-            elementAtCaret = psiFile.findElementAt(editor.getCaretModel().getOffset());
-            if (elementAtCaret != null && elementAtCaret.getParent() != null) {
+        if (psiFile != null)
+        {
+            Language selectedLanguage = _projectComponent.getSelectedLanguage();
+            FileViewProvider viewProvider = psiFile.getViewProvider();
+
+            if (selectedLanguage != null)
+            {
+                PsiFile selectedRoot = viewProvider.getPsi(selectedLanguage);
+                if (selectedRoot == null)
+                {
+                    selectedLanguage = null;
+                }
+            }
+
+            if (selectedLanguage == null)
+            {
+                selectedLanguage = psiFile.getLanguage();
+            }
+
+            elementAtCaret = viewProvider.findElementAt(editor.getCaretModel().getOffset(), selectedLanguage);
+
+            if (elementAtCaret != null && elementAtCaret.getParent() != null)
+            {
                 if (elementAtCaret.getParent().getChildren().length == 0)
                     elementAtCaret = elementAtCaret.getParent();
             }
         }
-        
-        if(elementAtCaret != null && elementAtCaret != getSelectedElement()) {
+
+        if (elementAtCaret != null && elementAtCaret != getSelectedElement())
+        {
             debug("new element at caret " + elementAtCaret + ", current root=" + getRootElement());
             if (!PsiTreeUtil.isAncestor(getRootElement(), elementAtCaret, false))
                 selectRootElement(psiFile, TITLE_PREFIX_CURRENT_FILE);


### PR DESCRIPTION
1. Table cell render at IDEA 14 (at least) crashes if thre is an incomplete HTML in it. Working example:

```
<html>
<head>http://template-toolkit.org/docs/manual/Variables.html</head>
<body>


<script type="text/javascript">
    var a = 5;
```
1. Also, pull request brings support for files with multiple psi trees in it. Added combo-box with available languages.
