### PR TITLE
Fixed class cast exception 

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -15,6 +15,10 @@
 
     <li>Fixed the toolwindow icons</li>
 
+    <li>Added support for multi-psi files</li>
+
+    <li>Fixed class cast exception if PsiElement's method returns array of primitives</li>
+
 </ul>
 
 </html>]]></change-notes>

--- a/src/idea/plugin/psiviewer/view/PropertySheetPanel.java
+++ b/src/idea/plugin/psiviewer/view/PropertySheetPanel.java
@@ -18,6 +18,7 @@ import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.List;
 
@@ -186,11 +187,12 @@ public class PropertySheetPanel extends JPanel
         if (!object.getClass().isArray()) return object.toString();
         StringBuffer buf = new StringBuffer();
         buf.append("[");
-        Object[] array = (Object[]) object;
-        for (int i = 0; i < array.length; i++) // fixme what if length is 100_500_000 ?
+        int arrayLength = Array.getLength(object);
+        for (int i = 0; i < arrayLength; i++) // fixme what if length is 100_500_000 ?
         {
             if (i != 0) buf.append(", ");
-            buf.append(array[i] == null ? "null" : array[i].toString());
+            Object arrayItem = Array.get(object, i);
+            buf.append(arrayItem == null ? "null" : arrayItem.toString());
         }
         buf.append("]");
         return buf.toString();


### PR DESCRIPTION
Happens if PsiElement's method returns an array of primitives
Also, updated changes
