### PR TITLE
Read lock assertions in psi viewer tree model

### DIFF
--- a/src/main/java/idea/plugin/psiviewer/model/PsiViewerTreeModel.java
+++ b/src/main/java/idea/plugin/psiviewer/model/PsiViewerTreeModel.java
@@ -61,7 +61,7 @@ public class PsiViewerTreeModel implements TreeModel {
 
     public boolean isLeaf(Object node) {
         PsiElement psi = (PsiElement) node;
-        return getFilteredChildren(psi).size() == 0;
+        return getFilteredChildren(psi).isEmpty();
     }
 
     private List<PsiElement> getFilteredChildren(PsiElement psi) {
@@ -80,6 +80,7 @@ public class PsiViewerTreeModel implements TreeModel {
     }
 
     public int getIndexOfChild(Object parent, Object child) {
+        if (!(child instanceof PsiElement)) return -1;
         PsiElement psiParent = (PsiElement) parent;
         List<PsiElement> psiChildren = getFilteredChildren(psiParent);
 

--- a/src/main/java/idea/plugin/psiviewer/model/PsiViewerTreeModel.java
+++ b/src/main/java/idea/plugin/psiviewer/model/PsiViewerTreeModel.java
@@ -40,6 +40,7 @@ public class PsiViewerTreeModel implements TreeModel {
         myPsiViewerProjectService = projectComponent;
     }
 
+    @Override
     public Object getRoot() {
         return myRootElement;
     }
@@ -48,17 +49,20 @@ public class PsiViewerTreeModel implements TreeModel {
         myRootElement = root;
     }
 
+    @Override
     public Object getChild(Object parent, int index) {
         PsiElement psi = (PsiElement) parent;
         List<PsiElement> children = getFilteredChildren(psi);
         return children.get(index);
     }
 
+    @Override
     public int getChildCount(Object parent) {
         PsiElement psi = (PsiElement) parent;
         return getFilteredChildren(psi).size();
     }
 
+    @Override
     public boolean isLeaf(Object node) {
         PsiElement psi = (PsiElement) node;
         return getFilteredChildren(psi).isEmpty();
@@ -79,6 +83,7 @@ public class PsiViewerTreeModel implements TreeModel {
         return !myPsiViewerProjectService.isFilterWhitespace() || !(psiElement instanceof PsiWhiteSpace);
     }
 
+    @Override
     public int getIndexOfChild(Object parent, Object child) {
         if (!(child instanceof PsiElement)) return -1;
         PsiElement psiParent = (PsiElement) parent;
@@ -87,12 +92,15 @@ public class PsiViewerTreeModel implements TreeModel {
         return psiChildren.indexOf(child);
     }
 
+    @Override
     public void valueForPathChanged(TreePath path, Object newValue) {
     }
 
+    @Override
     public synchronized void addTreeModelListener(TreeModelListener l) {
     }
 
+    @Override
     public synchronized void removeTreeModelListener(TreeModelListener l) {
     }
 }

--- a/src/main/java/idea/plugin/psiviewer/model/PsiViewerTreeModel.java
+++ b/src/main/java/idea/plugin/psiviewer/model/PsiViewerTreeModel.java
@@ -22,6 +22,7 @@
 
 package idea.plugin.psiviewer.model;
 
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiWhiteSpace;
 import idea.plugin.psiviewer.controller.project.PsiViewerProjectService;
@@ -69,14 +70,16 @@ public class PsiViewerTreeModel implements TreeModel {
     }
 
     private List<PsiElement> getFilteredChildren(PsiElement psi) {
-        final List<PsiElement> filteredChildren = new ArrayList<>();
+        return ReadAction.compute(() -> {
+            final List<PsiElement> filteredChildren = new ArrayList<>();
 
-        for (PsiElement e = psi.getFirstChild(); e != null; e = e.getNextSibling())
-            if (isValid(e)) {
-                filteredChildren.add(e);
-            }
+            for (PsiElement e = psi.getFirstChild(); e != null; e = e.getNextSibling())
+                if (isValid(e)) {
+                    filteredChildren.add(e);
+                }
 
-        return filteredChildren;
+            return filteredChildren;
+        });
     }
 
     private boolean isValid(PsiElement psiElement) {


### PR DESCRIPTION
See https://jb-web.exa.aws.intellij.net/issue/994763

```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is allowed from inside read-action (see Application.runReadAction()); see https://jb.gg/ij-platform-threading for details
Current thread: Thread[AWT-EventQueue-0,6,main] 508699757 (EventQueue.isDispatchThread()=true)
SystemEventQueueThread: (same)
	at com.intellij.util.concurrency.ThreadingAssertions.createThreadAccessException(ThreadingAssertions.java:149)
	at com.intellij.util.concurrency.ThreadingAssertions.softAssertReadAccess(ThreadingAssertions.java:107)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:1012)
	at com.intellij.psi.impl.file.impl.FileManagerImpl.getCachedPsiFile(FileManagerImpl.java:365)
	at com.jetbrains.cidr.lang.preprocessor.OCInclusionContextUtil.findCachedPsiFile(OCInclusionContextUtil.java:35)
	at com.jetbrains.cidr.lang.symbols.symtable.OCSymbolTableProvider.accepts(OCSymbolTableProvider.java:90)
	at com.jetbrains.cidr.lang.symbols.symtable.FileSymbolTableHelper.findProvider(FileSymbolTableHelper.kt:35)
	at com.jetbrains.cidr.lang.symbols.symtable.FileSymbolTableHelper.isPreProcessable(FileSymbolTableHelper.kt:27)
	at com.jetbrains.cidr.lang.util.OCCodeInsightUtil.isPreProcessable(OCCodeInsightUtil.java:708)
	at com.jetbrains.cidr.lang.preprocessor.OCInclusionContextImpl$1Builder.processFileInclude(OCInclusionContextImpl.java:1218)
	at com.jetbrains.cidr.lang.preprocessor.OCInclusionContextImpl$1Builder.process(OCInclusionContextImpl.java:1057)
	at com.jetbrains.cidr.lang.resolve.OCResolveUtil.processSymbolsFromList(OCResolveUtil.java:841)
	at com.jetbrains.cidr.lang.preprocessor.OCInclusionContextImpl.preprocessFileImpl(OCInclusionContextImpl.java:1239)
	at com.jetbrains.cidr.lang.preprocessor.OCInclusionContextImpl.preprocessFile(OCInclusionContextImpl.java:1008)
	at com.jetbrains.cidr.lang.parser.OCParser.evaluatePartialContext(OCParser.java:454)
	at com.jetbrains.cidr.lang.parser.OCParser.lambda$parse$4(OCParser.java:254)
	at com.jetbrains.cidr.lang.parser.OCParser.computeSyncWithEDTPriority(OCParser.java:359)
	at com.jetbrains.cidr.lang.parser.OCParser.parse(OCParser.java:213)
	at com.jetbrains.cidr.lang.parser.OCReparseablePsiElementType.doParseContents(OCReparseablePsiElementType.java:34)
	at com.intellij.psi.tree.ILazyParseableElementType.parseContents(ILazyParseableElementType.java:50)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.lambda$ensureParsed$2(LazyParseableElement.java:183)
	at com.intellij.psi.impl.DebugUtil.performPsiModification(DebugUtil.java:535)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.ensureParsed(LazyParseableElement.java:182)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.getFirstChildNode(LazyParseableElement.java:234)
	at com.jetbrains.cidr.lang.psi.impl.OCLazyElementBase.lambda$getFirstChildNode$0(OCLazyElementBase.java:144)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:73)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:192)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:685)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:641)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:609)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:179)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:73)
	at com.jetbrains.cidr.lang.parser.OCParser.computeSyncWithEDTPriority(OCParser.java:362)
	at com.jetbrains.cidr.lang.psi.impl.OCLazyElementBase.getFirstChildNode(OCLazyElementBase.java:144)
	at com.intellij.psi.impl.source.tree.LazyParseablePsiElement.getFirstChild(LazyParseablePsiElement.java:82)
	at idea.plugin.psiviewer.model.PsiViewerTreeModel.getFilteredChildren(PsiViewerTreeModel.java:70)
	at idea.plugin.psiviewer.model.PsiViewerTreeModel.isLeaf(PsiViewerTreeModel.java:64)
	at com.intellij.ui.tree.ui.DefaultTreeUI.isLeaf(DefaultTreeUI.java:207)
	at com.intellij.ui.tree.ui.DefaultTreeUI$2.getNodeDimensions(DefaultTreeUI.java:589)
	at java.desktop/javax.swing.tree.AbstractLayoutCache.getNodeDimensions(AbstractLayoutCache.java:497)
	at com.intellij.ui.tree.ui.DefaultTreeLayoutCache.access$getNodeDimensions(DefaultTreeLayoutCache.kt:19)
	at com.intellij.ui.tree.ui.DefaultTreeLayoutCache$Node.getBounds(DefaultTreeLayoutCache.kt:485)
	at com.intellij.ui.tree.ui.DefaultTreeLayoutCache.getPreferredWidth(DefaultTreeLayoutCache.kt:148)
	at java.desktop/javax.swing.plaf.basic.BasicTreeUI.updateCachedPreferredSize(BasicTreeUI.java:2210)
	at com.intellij.ui.tree.ui.DefaultTreeUI.updateCachedPreferredSize(DefaultTreeUI.java:523)
	at java.desktop/javax.swing.plaf.basic.BasicTreeUI.getPreferredSize(BasicTreeUI.java:2335)
	at java.desktop/javax.swing.JComponent.getPreferredSize(JComponent.java:1721)
	at com.intellij.ui.components.JBScrollPane$Layout.layoutContainer(JBScrollPane.java:533)
	at java.desktop/java.awt.Container.layout(Container.java:1541)
	at java.desktop/java.awt.Container.doLayout(Container.java:1530)
	at java.desktop/java.awt.Container.validateTree(Container.java:1725)
	at java.desktop/java.awt.Container.lambda$validate$3(Container.java:1659)
	at java.desktop/sun.awt.SunToolkit.performWithTreeLock(SunToolkit.java:2161)
	at java.desktop/java.awt.Container.validate(Container.java:1648)
	at java.desktop/javax.swing.RepaintManager$3.run(RepaintManager.java:760)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/javax.swing.RepaintManager.validateInvalidComponents(RepaintManager.java:757)
	at java.desktop/javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1908)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:792)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:739)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:761)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:695)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$12(IdeEventQueue.kt:589)
	at com.intellij.openapi.application.impl.RwLockHolder.runWithoutImplicitRead(RwLockHolder.kt:44)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:72)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:355)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:793)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:354)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1014)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1014)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:349)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:386)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```