### PR TITLE
Fix typos in CookieManager comments

### DIFF
--- a/src/main/java/com/sylvanaar/idea/errorreporting/CookieManager.java
+++ b/src/main/java/com/sylvanaar/idea/errorreporting/CookieManager.java
@@ -28,7 +28,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**
- * CookieManager is a simple utilty for handling cookies when working
+ * CookieManager is a simple utility for handling cookies when working
  * with <code>java.net.URL</code> and <code>java.net.URLConnection</code>
  * objects.
  *
@@ -135,7 +135,7 @@ for (int i=1; (headerName = conn.getHeaderFieldKey(i)) != null; i++) {
 
 /**
  * Prior to opening a URLConnection, calling this method will set all
- * unexpired cookies that match the path or subpaths for thi underlying URL
+ * unexpired cookies that match the path or subpaths for the underlying URL
  *
  * The connection MUST NOT have been opened
  * method or an IOException will be thrown.


### PR DESCRIPTION
## Summary
- fix typos in CookieManager's JavaDoc

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve IntelliJ Platform dependency)*

------
https://chatgpt.com/codex/tasks/task_e_683fee8a8e348328bdc7caaf09d998fd